### PR TITLE
minor issue in build system

### DIFF
--- a/Program/configure.ac
+++ b/Program/configure.ac
@@ -15,7 +15,7 @@ if test -n "$host_alias" ; then
 	LIBS="$LIBS -L. -lftd2xx"
 else
 	PKG_CHECK_MODULES([libftdi], [libftdi >= 0.16],
-		[CFLAGS="$CFLAGS $libftdi_CFLAGS";
+		[CPPFLAGS="$CPPFLAGS $libftdi_CFLAGS";
 		LIBS="$LIBS $libftdi_LIBS"])
 fi
 


### PR DESCRIPTION
hi, I noticed a minor issue in the configure.ac, instead of configuring CFLAGS for libftdi, it should  be CPPFLAGS, else the proper directory isn't included in the include search path.
