### PR TITLE
Add newline to printout

### DIFF
--- a/papilio-prog/butterfly.cpp
+++ b/papilio-prog/butterfly.cpp
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
             fpga_bit.readFile(cBscan_fn);
 	    //fpga_bit.print();
 	    
-            printf("\nUploading \"%s\". ", cBscan_fn);
+            printf("\nUploading \"%s\".\n", cBscan_fn);
             alg.array_program(fpga_bit);
 
             BitFile flash_bit;
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
 
             fpga_bit.print();
 
-            printf("\nUploading \"%s\". ", cFpga_fn);
+            printf("\nUploading \"%s\".\n", cFpga_fn);
             alg.array_program(fpga_bit);
             return 0;
 	  }


### PR DESCRIPTION
The last line of text after doing an upload was ``Uploading "..."''  but it didn't have a newline. This patch adds a newline so the prompt starts on a new line like it should.
