### PR TITLE
Bump to libftdi1

### DIFF
--- a/papilio-prog/configure.ac
+++ b/papilio-prog/configure.ac
@@ -14,9 +14,9 @@ if test -n "$host_alias" ; then
 	AC_DEFINE([WINDOWS], 1, [Cross-compiling for windows])
 	LIBS="$LIBS -L. -lftd2xx"
 else
-	PKG_CHECK_MODULES([libftdi], [libftdi >= 0.16],
-		[CPPFLAGS="$CPPFLAGS $libftdi_CFLAGS";
-		LIBS="$LIBS $libftdi_LIBS"])
+	PKG_CHECK_MODULES([libftdi1], [libftdi1 >= 1],
+		[CPPFLAGS="$CPPFLAGS $libftdi1_CFLAGS";
+		LIBS="$LIBS $libftdi1_LIBS"])
 fi
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
libftdi1 is the most common version in distros now, and as a side note libftdi-0.20 is broken on my distro (Gentoo, the libftdi.pc has an empty Version field which prevents papilio-prog to build, the problem is from upstream, Debian corrects it I don't know how).
