### PR TITLE
Using int instead of char for getopt return.

### DIFF
--- a/papilio-prog/butterfly.cpp
+++ b/papilio-prog/butterfly.cpp
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
     char const *serial = 0;
     int subtype = FTDI_NO_EN;
     char *devicedb = NULL;
-    char c;
+    int c;
     char *cFpga_fn=0;
     char *cBscan_fn=0;
     char *append_str = 0;


### PR DESCRIPTION
This causes a failure on Raspbian, where 'char' is unsigned. The EOF check fails.