### PR TITLE
Added support for N25P80 SPI Flash.

### DIFF
--- a/papilio-prog/progalgspi.cpp
+++ b/papilio-prog/progalgspi.cpp
@@ -248,6 +248,23 @@ bool ProgAlgSpi::Spi_Identify(bool verbose)
                 if(verbose)
                     printf("Found Numonyx/Micron Flash (Pages=%d, Page Size=%d bytes, %d bits).\n",Pages,PageSize,Pages*PageSize*8);
                 break;
+            } if (tdo[2] == 0x20) { //N25PXXX
+                switch(tdo[3])
+                {
+                    case 0x14: /* N25P80 */
+                        Pages=4096;
+                        PageSize=256;
+                        BulkErase=20;
+                        SectorErase=3;
+                        FlashType=GENERIC;
+                        break;
+                    default:
+                        printf("Unknown Numonyx/Micron N25P Flash Size (0x%.2x)\n", tdo[3]);
+                        return false;
+                }
+                if(verbose)
+                  printf("Found Numonyx/Micron Flash (Pages=%d, Page Size=%d bytes, %d bits).\n",Pages,PageSize,Pages*PageSize*8);
+                break;
             } else {
                 printf("Unknown Numonyx/Micron Flash Type (0x%.2x)\n", tdo[2]);
                 return false;


### PR DESCRIPTION
I noticed the N25P series flash chips were not supported in the Papilio Loader, and I needed to program one for a non-Papilio board that I had. So I added support for the N25P80 SPI Flash. I've tested it on the board that I have and it works.

If you want me to add support for the other chips in the series, I will add them based on the data sheets, but I cannot fully test them.